### PR TITLE
修复NewBing JavaScript资源更新导致的错误

### DIFF
--- a/frontend/public/js/bing/chat/core.js
+++ b/frontend/public/js/bing/chat/core.js
@@ -10,10 +10,10 @@
 }
 )(_w.onload, _w.si_PP);
 _w.rms.js(
-  { 'A:rms:answers:Shared:BingCore.Bundle': '/rp/Bwcx9lYZzDVeFshx5WQGC-o1Sas.br.js' },
+  { 'A:rms:answers:Shared:BingCore.Bundle': '/rp/Pki1-YEXD6vos5MiDyyAeDq7sgs.br.js' },
   { 'A:rms:answers:Web:SydneyFSCHelper': '/rp/h8iJ1DxS_EC8EO0uy_IB7zKwM98.br.js' },
   { 'A:rms:answers:VisualSystem:ConversationScope': '/rp/Hiynn7BhKG6O2vgQFThQvnyzUyM.br.js' },
-  { 'A:rms:answers:CodexBundle:cib-bundle': '/rp/3CVA3HVOsO9PskCMrYTMxMDIi1U.br.js' },
+  { 'A:rms:answers:CodexBundle:cib-bundle': '/rp/1tz7N7cPo5mo68ojCrW9s1He9HQ.br.js' },
   { 'A:rms:answers:SharedStaticAssets:speech-sdk': '/rp/6slp3E-BqFf904Cz6cCWPY1bh9E.br.js' },
   { 'A:rms:answers:Web:SydneyWelcomeScreenBase':'/rp/_Eg7XX2el4yFXBdqXLVFaQjHxOM.br.js' },
   { 'A:rms:answers:Web:SydneyWelcomeScreen':'/rp/MT9w5YvjxYHdcyXSS0tDquzGw2Y.br.js' },

--- a/web/js/bing/chat/core.js
+++ b/web/js/bing/chat/core.js
@@ -10,10 +10,10 @@
 }
 )(_w.onload, _w.si_PP);
 _w.rms.js(
-  { 'A:rms:answers:Shared:BingCore.Bundle': '/rp/Bwcx9lYZzDVeFshx5WQGC-o1Sas.br.js' },
+  { 'A:rms:answers:Shared:BingCore.Bundle': '/rp/Pki1-YEXD6vos5MiDyyAeDq7sgs.br.js' },
   { 'A:rms:answers:Web:SydneyFSCHelper': '/rp/h8iJ1DxS_EC8EO0uy_IB7zKwM98.br.js' },
   { 'A:rms:answers:VisualSystem:ConversationScope': '/rp/Hiynn7BhKG6O2vgQFThQvnyzUyM.br.js' },
-  { 'A:rms:answers:CodexBundle:cib-bundle': '/rp/3CVA3HVOsO9PskCMrYTMxMDIi1U.br.js' },
+  { 'A:rms:answers:CodexBundle:cib-bundle': '/rp/1tz7N7cPo5mo68ojCrW9s1He9HQ.br.js' },
   { 'A:rms:answers:SharedStaticAssets:speech-sdk': '/rp/6slp3E-BqFf904Cz6cCWPY1bh9E.br.js' },
   { 'A:rms:answers:Web:SydneyWelcomeScreenBase':'/rp/_Eg7XX2el4yFXBdqXLVFaQjHxOM.br.js' },
   { 'A:rms:answers:Web:SydneyWelcomeScreen':'/rp/MT9w5YvjxYHdcyXSS0tDquzGw2Y.br.js' },


### PR DESCRIPTION
此补丁包括两个core.js的修复，根据 #225 ，修改这两个资源地址为新路径即可。 