### PR TITLE
[bugfix] - 处理不是brotli编码的/rp/*.js

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -6,7 +6,7 @@ const MUID = '';
 const _U = '';
 
 const WEB_CONFIG = {
-  WORKER_URL: '', // 如无特殊需求请，保持为''
+  WORKER_URL: '', // 请保持默认的''，不要配置该项。
 };
 
 const SYDNEY_ORIGIN = 'https://sydney.bing.com';
@@ -130,16 +130,21 @@ const rewriteBody = async (res) => {
     let body = res.body;
      if (content_type.startsWith("text/html")) {
        body = res.body;
-     } else if (res.url.endsWith("br.js") && content_encoding == 'br') {
-      const decodedContent = new TextDecoder("utf-8").decode(brotli_decode(new Int8Array(await res.clone().arrayBuffer())));
-      if (decodedContent) {
-        // @ts-ignore
-        body = decodedContent.replaceAll("www.bing.com", WEB_CONFIG.WORKER_URL.replace("http://", "").replace("https://", ""));
-        encoding = 'gzip';
+     } else if (res.url.endsWith("js")) {
+      if (res.url.includes('/rp/')) {
+        let decodedContent = null;
+        if (content_encoding == 'br') {
+          decodedContent = new TextDecoder("utf-8").decode(brotli_decode(new Int8Array(await res.clone().arrayBuffer())));
+          encoding = 'gzip';
+        } else {
+          decodedContent = new TextDecoder("utf-8").decode(new Int8Array(await res.clone().arrayBuffer()));
+        }
+        if (decodedContent) {
+          // @ts-ignore
+          body = decodedContent.replaceAll("www.bing.com", WEB_CONFIG.WORKER_URL.replace("http://", "").replace("https://", ""));
+        }
       }
     }
-   //console.log(res.url);
-   //console.log({body, encoding});
    return {body, encoding};
 }
 
@@ -210,11 +215,7 @@ export default {
     });
     newHeaders.set('host', targetUrl.host);
     newHeaders.set('origin', targetUrl.origin);
-    if (request.headers.get('referer').indexOf('web/compose.html') != -1) {
-      newHeaders.set('referer', 'https://edgeservices.bing.com/edgesvc/compose');
-    } else {
-      newHeaders.set('referer', 'https://www.bing.com/search?q=Bing+AI&showconv=1&FORM=hpcodx');
-    }
+    newHeaders.set('referer', 'https://www.bing.com/search?q=Bing+AI');
     const randIP = getRandomIP();
     // console.log('randIP : ', randIP);
     newHeaders.set('X-Forwarded-For', randIP);


### PR DESCRIPTION
对某些老旧的客户端可能不支持brotli编解码，bing会将/rp/*.js回退至gzip，原worker.js默认将这些*.js作为brotli编码来进行处理。