### PR TITLE
高频垃圾请求拦截

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,86 @@
   <meta name="referrer" content="origin-when-cross-origin" />
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <title>BingAI - 聊天</title>
+  <!-- 高频垃圾请求拦截 -->
+  <script>
+    //垃圾请求拦截器，屏蔽掉的都是用于统计的高频请求，聊一次发几百次的
+    (() => {
+        //解析器
+        function pathOrUrl(value) {
+            if (!value) {
+                return undefined;
+            }
+            if ((typeof value) != "string") {
+                value = `${value};`
+            }
+            try {
+                return new URL(value);
+            } catch (e) {
+                if (value.startsWith("/")) {
+                    let url = new URL(`${window.location.origin}${value}`)
+                    return url
+                } else {
+                    return new URL(`${window.location.href.substring(0, window.location.href.lastIndexOf("/"))}/${value}`);
+                }
+            }
+        }
+
+        //feth请求编辑
+        const myFetch = window.fetch;
+        window.fetch = (input, init) => {
+            let url = pathOrUrl(input);
+            if (url) {
+                if (url.hostname == "www.bing.com") {
+                    url.hostname = window.location.hostname;
+                    url.port = window.location.port;
+                    url.protocol = window.location.protocol;
+                    console.log("已拦重定向请求=>", input, url.toString());
+                    return myFetch(url, init);
+                }
+            }
+            return myFetch(input, init);
+        }
+        //xml请求编辑
+        const myXMLHttpRequestOpen = window.XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function () {
+            let url = pathOrUrl(arguments[1]);
+            if (url) {
+                if(url.pathname=="/fd/ls/lsp.aspx"){
+                    console.log("已拦截无用请求=>", arguments);
+                    return;
+                }
+            }
+            console.log(arguments);
+            return myXMLHttpRequestOpen.apply(this, arguments);
+        }
+
+        //sendBeacon请求
+        const mySendBeacon = window.navigator.sendBeacon;
+        window.navigator.sendBeacon = (url, data)=>{
+            console.log("已拦截无用统计请求=>", url,data);
+        }
+
+        //img请求
+        const myImage = window.Image;
+        window.Image = new Proxy(myImage, {
+            construct(target, argumentsList) {
+                return new Proxy(new myImage(...argumentsList), {
+                    set(target, property, value) {
+                        const url = pathOrUrl(value);
+                        if (url) {
+                            if (url.pathname == "/fd/ls/l") {
+                                console.log("已拦截无用请求=>", value);
+                                return;
+                            }
+                        }
+                        console.log(url,value);
+                        target[property] = value;
+                    }
+                });
+            }
+        })
+    })();
+  </script>
   <!-- Google tag Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZVJCFLBFRZ"></script>
   <script>


### PR DESCRIPTION
拦截掉大量用于统计的高频垃圾请求，减少 80% workers 请求次数消耗。

干干净净，再见垃圾请求。
![image](https://github.com/Harry-zklcdc/go-proxy-bingai/assets/59829816/efb30627-fbff-4122-82b1-e5338dd0850b)
