### PR TITLE
[Fix] 🐛 typo in cloudflare-worker-deploy.yml

### DIFF
--- a/.github/workflows/cloudflare-worker-deploy.yml
+++ b/.github/workflows/cloudflare-worker-deploy.yml
@@ -1,4 +1,4 @@
-name: Cloudfalre Worker Deploy
+name: Cloudflare Worker Deploy
 on:
   push:
     branches:


### PR DESCRIPTION
```Cloudfalre``` -> ```Cloudflare```